### PR TITLE
URL Cleanup

### DIFF
--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -1,7 +1,7 @@
 // tag::snippetA[]
 buildscript {
     repositories {
-        maven { url "http://repo.spring.io/libs-release" }
+        maven { url "https://repo.spring.io/libs-release" }
     }
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:1.3.3.RELEASE")
@@ -23,7 +23,7 @@ subprojects { subproject ->
     version =  '0.1.0'
     repositories {
         mavenCentral()
-        maven { url "http://repo.spring.io/libs-release" }
+        maven { url "https://repo.spring.io/libs-release" }
     }
     dependencies {
         compile("org.springframework.data:spring-yarn-boot:2.4.0.RELEASE")


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://repo.spring.io/libs-release migrated to:  
  https://repo.spring.io/libs-release ([https](https://repo.spring.io/libs-release) result 302).